### PR TITLE
allow symfony/framework-bundle version 4.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": "^7.1",
     "contao/core-bundle": "^4.4",
-    "symfony/framework-bundle": "^3.4",
+    "symfony/framework-bundle": "^3.4|^4.1",
     "heimrichhannot/contao-multi-column-editor-bundle": "^1.0",
     "matthiasmullie/minify": "~1.3",
     "heimrichhannot/contao-utils-bundle": "^2.3"


### PR DESCRIPTION
Needed for contao 4.6